### PR TITLE
Support for <em> and underline tags and separating blank (as used in TinyMCE)

### DIFF
--- a/vsword/node/TextNode.php
+++ b/vsword/node/TextNode.php
@@ -10,7 +10,7 @@
 class TextNode extends Node implements INodeTextAdded, ILineContext {
 	protected $text;
 	
-        
+
 	public function __construct($text = '') {
 		$this->addText($text);  
 	}

--- a/vsword/node/TextNode.php
+++ b/vsword/node/TextNode.php
@@ -42,7 +42,9 @@ class TextNode extends Node implements INodeTextAdded, ILineContext {
 	 
 	
 	public function getWord() {
-		return '<w:t>'.$this->getText().'</w:t>';
+		//space-preserve needed e.g. for "This is <b>bold</b> text." (otherwise text would read "This isboldtext.")
+		return (' '==substr($this->getText(),0,1) || ' '==substr($this->getText(),-1) ? '<w:t xml:space="preserve">' :'<w:t>').
+			   $this->getText().'</w:t>';
 	}
 	
 	 

--- a/vsword/parser/DefaultInitNode.php
+++ b/vsword/parser/DefaultInitNode.php
@@ -49,13 +49,16 @@ class DefaultInitNode implements IInitNode {
             case 'p': //case 'div': TODO interpret DIV as PCompositeNode ?
                 return new PCompositeNode();
                 break;
-            case 'br':case 'hr':
+            case 'br': case 'hr':
                 return new BrNode();
                 break;
             case 'span':
+                if (array_key_exists('style',$attributes) && $attributes['style']=='text-decoration: underline;') {
+                    $r = new RCompositeNode(); $r->addTextStyle(new UnderlineStyleNode()); return $r; //support TinyMCE-underline
+                }
                 return new RCompositeNode();
                 break;
-            case 'i':
+            case 'i': case 'em': //browsers interpret <em> as <i> (used for italic in TinyMCE)
                 $r = new RCompositeNode();
                 $r->addTextStyle(new ItalicStyleNode());
                 return $r;
@@ -114,7 +117,7 @@ class DefaultInitNode implements IInitNode {
             case 'a':
                 $link = new HyperlinkCompositeNode();
                 if(isset($attributes['href'])) {  
-                     $linkId = $this->getVsWord()->getAttachHyperLink($attributes['href']);                     
+                     $linkId = $this->getVsWord()->getAttachHyperLink($attributes['href']);
                      $link->setLinkId($linkId);
                 } 
                 return $link;

--- a/vsword/parser/HTMLLoader.php
+++ b/vsword/parser/HTMLLoader.php
@@ -16,6 +16,7 @@ class HTMLLoader {
      */
     public function noEmptyText($text) {
         //return trim($text) != ''; (within a paragraph there may be a blank between two formatting parts)
+        //Example (TinyMCE generated): "This is <b>bold</b> <em>italic</em> text." should be correctly formatted.
         return trim($text,"\r\n\t") != '';
     }
 

--- a/vsword/parser/HTMLLoader.php
+++ b/vsword/parser/HTMLLoader.php
@@ -15,7 +15,8 @@ class HTMLLoader {
      * @return boolean
      */
     public function noEmptyText($text) {
-        return trim($text) != '';
+        //return trim($text) != ''; (within a paragraph there may be a blank between two formatting parts)
+        return trim($text,"\r\n\t") != '';
     }
 
     public function parseFromUrl($url) {


### PR DESCRIPTION
HTML text may contain em-tag, underline, blanks at end of text runs (space-preserve) and single spaces inbetween. Tags supported in DefaultInitNode, TextNode (space-preserve).
Example HTML created by TinyMCE:
This is <em>italic</em> <span style="text-decoration: underline;">underline</span> text.